### PR TITLE
Add .nvmrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ yarn-error.*
 
 # typescript
 *.tsbuildinfo
+
+
+# node version
+.nvmrc


### PR DESCRIPTION
Updated .gitignore to exclude the .nvmrc file, preventing it from being tracked by git.